### PR TITLE
Add Tailwind Across Other Views

### DIFF
--- a/src/NZFurs.Auth/Views/Account/ConfirmEmail.cshtml
+++ b/src/NZFurs.Auth/Views/Account/ConfirmEmail.cshtml
@@ -3,8 +3,8 @@
 @{
     ViewData["Title"] = @SharedLocalizer.GetLocalizedHtmlString("CONFIRM_EMAIL");
 }
-<h2>@ViewData["Title"].</h2>
-<div>
+<h2 class="text-2xl m-6 text-nz-green-light text-center">@ViewData["Title"].</h2>
+<div class="container mx-auto h-full flex justify-center items-center">
     <p>
         @SharedLocalizer.GetLocalizedHtmlString("CONFIRM_EMAIL_TEXT")
     </p>

--- a/src/NZFurs.Auth/Views/Account/ExternalLoginConfirmation.cshtml
+++ b/src/NZFurs.Auth/Views/Account/ExternalLoginConfirmation.cshtml
@@ -4,28 +4,26 @@
 @{
     ViewData["Title"] = @SharedLocalizer.GetLocalizedHtmlString("REGISTER");
 }
-<h2>@ViewData["Title"].</h2>
-<h4>  @SharedLocalizer.GetLocalizedHtmlString("EXTERNAL_LOGIN_ASSOCIATE_ACCOUNT", ViewData["LoginProvider"].ToString())</h4>
-<form asp-controller="Account" asp-action="ExternalLoginConfirmation" asp-route-returnurl="@ViewData["ReturnUrl"]" method="post" class="form-horizontal">
-    <h4>Association Form</h4>
-    <hr />
-    <div asp-validation-summary="All" class="text-danger"></div>
-    <p class="text-info">
-        @SharedLocalizer.GetLocalizedHtmlString("EXTERNAL_LOGIN_ASSOCIATE_ACCOUNT", ViewData["LoginProvider"].ToString())
-    </p>
-    <div class="form-group">
-        <label asp-for="Email" class="col-md-2 control-label">@SharedLocalizer.GetLocalizedHtmlString("EMAIL")</label>
-        <div class="col-md-10">
-            <input asp-for="Email" class="form-control" />
-            <span asp-validation-for="Email" class="text-danger"></span>
-        </div>
+<h2 class="text-2xl m-6 text-nz-green-light text-center">@ViewData["Title"].</h2>
+<h4 class="text-l mt-10 mb-4  text-nz-green-light text-center">  @SharedLocalizer.GetLocalizedHtmlString("EXTERNAL_LOGIN_ASSOCIATE_ACCOUNT", ViewData["LoginProvider"].ToString())</h4>
+
+<div class="container mx-auto h-full flex justify-center items-center">
+    <div class="w-1/3">
+        <form asp-controller="Account" asp-action="ExternalLoginConfirmation" asp-route-returnurl="@ViewData["ReturnUrl"]" method="post" class="form-horizontal">
+            <div asp-validation-summary="All" class="text-red"></div>
+            <p class="text-white mb-4">
+                @SharedLocalizer.GetLocalizedHtmlString("EXTERNAL_LOGIN_ASSOCIATE_ACCOUNT", ViewData["LoginProvider"].ToString())
+            </p>
+            <div class="mb-4">
+                <label asp-for="Email" class="font-bold text-nz-green-light block mb-2">@SharedLocalizer.GetLocalizedHtmlString("EMAIL")</label>
+                <input asp-for="Email" class="mb-2 block appearance-none max-w-full w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" />
+                <span asp-validation-for="Email" class="text-red"></span>
+            </div>
+            <button type="submit" class="w-full mt-8 bg-yellow hover:bg-yellow-darker text-green-darkest hover:text-white font-bold py-2 px-4 rounded">@SharedLocalizer.GetLocalizedHtmlString("REGISTER");</button>             
+        </form>
     </div>
-    <div class="form-group">
-        <div class="col-md-offset-2 col-md-10">
-            <button type="submit" class="btn btn-primary">@SharedLocalizer.GetLocalizedHtmlString("REGISTER");</button>
-        </div>
-    </div>
-</form>
+</div>
+
 @section Scripts {
     @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
 }

--- a/src/NZFurs.Auth/Views/Account/ExternalLoginFailure.cshtml
+++ b/src/NZFurs.Auth/Views/Account/ExternalLoginFailure.cshtml
@@ -4,6 +4,6 @@
     ViewData["Title"] = "Login Failure";
 }
 <header>
-    <h2>@ViewData["Title"].</h2>
-    <p class="text-danger">@SharedLocalizer.GetLocalizedHtmlString("UNSUCCESSFUL_LOGIN_WITH_SERVICE")</p>
+    <h2 class="text-2xl m-6 text-nz-green-light text-center">@ViewData["Title"].</h2>
+    <p class="text-red text-center">@SharedLocalizer.GetLocalizedHtmlString("UNSUCCESSFUL_LOGIN_WITH_SERVICE")</p>
 </header>

--- a/src/NZFurs.Auth/Views/Account/ForgotPassword.cshtml
+++ b/src/NZFurs.Auth/Views/Account/ForgotPassword.cshtml
@@ -5,19 +5,18 @@
     ViewData["Title"] = @SharedLocalizer.GetLocalizedHtmlString("FORGOT_YOUR_PASSWORD");
 }
 
-<h2>@ViewData["Title"]?</h2>
-<h4>@SharedLocalizer.GetLocalizedHtmlString("FORGOT_YOUR_PASSWORD_ENTER_EMAIL")</h4>
-<hr />
-<div class="row">
-    <div class="col-md-4">
+<h2 class="text-2xl m-6 text-nz-green-light text-center">@ViewData["Title"]</h2>
+<h4 class="text-l mt-10 mb-4  text-nz-green-light text-center">@SharedLocalizer.GetLocalizedHtmlString("FORGOT_YOUR_PASSWORD_ENTER_EMAIL")</h4>
+<div class="container mx-auto h-full flex justify-center items-center">
+    <div class="w-1/3">
         <form asp-controller="Account" asp-action="ForgotPassword" method="post">
-            <div asp-validation-summary="All" class="text-danger"></div>
-            <div class="form-group">
-                <label asp-for="Email">@SharedLocalizer.GetLocalizedHtmlString("EMAIL")</label>
-                <input asp-for="Email" class="form-control" />
-                <span asp-validation-for="Email" class="text-danger"></span>
+            <div asp-validation-summary="All" class="text-red"></div>
+            <div class="mb-4">
+                <label asp-for="Email" class="font-bold text-nz-green-light block mb-2">@SharedLocalizer.GetLocalizedHtmlString("EMAIL")</label>
+                <input asp-for="Email" class="block appearance-none max-w-full w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" />
+                <span asp-validation-for="Email" class="text-red"></span>
             </div>
-            <button type="submit" class="btn btn-primary">@SharedLocalizer.GetLocalizedHtmlString("SUBMIT")</button>
+            <button type="submit" class="w-full mt-8 bg-yellow hover:bg-yellow-darker text-green-darkest hover:text-white font-bold py-2 px-4 rounded">@SharedLocalizer.GetLocalizedHtmlString("SUBMIT")</button>
         </form>
     </div>
 </div>

--- a/src/NZFurs.Auth/Views/Account/ForgotPasswordConfirmation.cshtml
+++ b/src/NZFurs.Auth/Views/Account/ForgotPasswordConfirmation.cshtml
@@ -3,7 +3,9 @@
 @{
     ViewData["Title"] = @SharedLocalizer.GetLocalizedHtmlString("FORGOT_PASSWORD_CONFIRMATION");
 }
-<h2>@ViewData["Title"]</h2>
-<p>
-    @SharedLocalizer.GetLocalizedHtmlString("FORGOT_PASSWORD_CONFIRMATION_TEXT");
-</p>
+<h2 class="text-2xl m-6 text-nz-green-light text-center">@ViewData["Title"]</h2>
+<div class="container mx-auto h-full flex justify-center items-center">
+    <p>
+        @SharedLocalizer.GetLocalizedHtmlString("FORGOT_PASSWORD_CONFIRMATION_TEXT")
+    </p>
+</div>

--- a/src/NZFurs.Auth/Views/Account/Lockout.cshtml
+++ b/src/NZFurs.Auth/Views/Account/Lockout.cshtml
@@ -4,7 +4,7 @@
     ViewData["Title"] = @SharedLocalizer.GetLocalizedHtmlString("LOCKED_OUT");
 }
 <header>
-    <h1 class="text-danger">@ViewData["Title"]</h1>
-    <p class="text-danger">@SharedLocalizer.GetLocalizedHtmlString("LOCKED_OUT_TEXT")</p>
+    <h1 class="text-red">@ViewData["Title"]</h1>
+    <p class="text-red">@SharedLocalizer.GetLocalizedHtmlString("LOCKED_OUT_TEXT")</p>
 </header>
 

--- a/src/NZFurs.Auth/Views/Account/LoggedOut.cshtml
+++ b/src/NZFurs.Auth/Views/Account/LoggedOut.cshtml
@@ -2,7 +2,7 @@
 @using NZFurs.Auth.Resources
 @model NZFurs.Auth.Models.AccountViewModels.LoggedOutViewModel
 
-<div class="page-header">
+<div class="container mx-auto h-full flex justify-center items-center">
     <h1>
         <small>@SharedLocalizer.GetLocalizedHtmlString("LOGOUT_TEXT")</small>
     </h1>

--- a/src/NZFurs.Auth/Views/Account/Login.cshtml
+++ b/src/NZFurs.Auth/Views/Account/Login.cshtml
@@ -9,60 +9,58 @@
 
 <h2 class="text-2xl m-6 text-nz-green-light text-center">@ViewData["Title"]</h2>
 <div class="container mx-auto h-full flex justify-center items-center">
-    <div class="w-1/3">
-        <section>
-            <div class="p-8 bg-nz-green-light mb-6 rounded-lg">
-                <form asp-controller="Account" asp-action="Login" asp-route-returnurl="@Model.ReturnUrl" method="post"  >
-                    <div asp-validation-summary="All" class="list-reset" ></div>
-                    <div class="mb-4">
-                        <label class="font-bold text-green-darkest block mb-2" >@SharedLocalizer.GetLocalizedHtmlString("EMAIL")</label>
-                        <div  >
-                            <input asp-for="Email" class="block appearance-none w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" />
-                            <span asp-validation-for="Email" class="text-red" ></span>
-                        </div>
+    <section>
+        <div class="p-8 bg-nz-green-light mb-6 rounded-lg">
+            <form asp-controller="Account" asp-action="Login" asp-route-returnurl="@Model.ReturnUrl" method="post"  >
+                <div asp-validation-summary="All" class="list-reset" ></div>
+                <div class="mb-4">
+                    <label class="font-bold text-green-darkest block mb-2" >@SharedLocalizer.GetLocalizedHtmlString("EMAIL")</label>
+                    <div  >
+                        <input asp-for="Email" class="block appearance-none w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" />
+                        <span asp-validation-for="Email" class="text-red" ></span>
                     </div>
-                    <div class="mb-4">
-                        <label class="font-bold text-green-darkest block mb-2" >@SharedLocalizer.GetLocalizedHtmlString("PASSWORD")</label>
-                        <div  >
-                            <input asp-for="Password" class="block appearance-none w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" />
-                            <span asp-validation-for="Password" class="text-red" ></span>
-                        </div>
+                </div>
+                <div class="mb-4">
+                    <label class="font-bold text-green-darkest block mb-2" >@SharedLocalizer.GetLocalizedHtmlString("PASSWORD")</label>
+                    <div  >
+                        <input asp-for="Password" class="block appearance-none w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" />
+                        <span asp-validation-for="Password" class="text-red" ></span>
                     </div>
-                    <div class="mb-4 text-green-darkest">
-                        <label  >@SharedLocalizer.GetLocalizedHtmlString("REMEMBER_ME")</label>
-                        <input asp-for="RememberLogin"  />
+                </div>
+                <div class="mb-4 text-green-darkest">
+                    <label  >@SharedLocalizer.GetLocalizedHtmlString("REMEMBER_ME")</label>
+                    <input asp-for="RememberLogin"  />
+                </div>
+                <div class="mb-4">
+                    <div class="flex items-center justify-between">
+                        <button type="submit" class="w-full mt-8 bg-yellow hover:bg-yellow-darker text-green-darkest hover:text-white font-bold py-2 px-4 rounded" >@SharedLocalizer.GetLocalizedHtmlString("ACCOUNT_LOGIN")</button>
                     </div>
-                    <div class="mb-4">
-                        <div class="flex items-center justify-between">
-                            <button type="submit" class="bg-yellow hover:bg-yellow-darker text-green-darkest hover:text-white font-bold py-2 px-4 rounded" >@SharedLocalizer.GetLocalizedHtmlString("ACCOUNT_LOGIN")</button>
-                        </div>
-                    </div>
-                    <p class="mt-3 mb-10">
-                        <a class="mb-4 text-green-darkest hover:text-yellow-darker no-underline" asp-action="ForgotPassword">@SharedLocalizer.GetLocalizedHtmlString("FORGOT_YOUR_PASSWORD")</a>
-                    </p>
-                    @if (Model.ExternalProviders.Any())
-                    {
-                    <p>
-                        <ul class="list-reset flex">
-                            @foreach (var provider in Model.ExternalProviders)
-                            {
-                                <li class="mr-3">
-                                    <a 
-                                        class=" mr-4 mt-10 bg-yellow hover:bg-yellow-darker text-green-darkest hover:text-white font-bold py-2 px-4 rounded no-underline"
-                                        asp-action="ExternalLogin"
-                                        asp-route-provider="@provider.AuthenticationScheme"
-                                        asp-route-returnUrl="@Model.ReturnUrl">
-                                        @provider.DisplayName
-                                    </a>
-                                </li>
-                            }
-                        </ul>
-                    </p>
-                    }
-                </form>
-            </div>
-        </section>
-    </div>
+                </div>
+                <p class="mt-3 mb-10">
+                    <a class="mb-4 text-green-darkest hover:text-yellow-darker no-underline" asp-action="ForgotPassword">@SharedLocalizer.GetLocalizedHtmlString("FORGOT_YOUR_PASSWORD")</a>
+                </p>
+                @if (Model.ExternalProviders.Any())
+                {
+                <p>
+                    <ul class="list-reset flex">
+                        @foreach (var provider in Model.ExternalProviders)
+                        {
+                            <li class="mr-3">
+                                <a 
+                                    class="no-underline w-full mt-8 bg-yellow hover:bg-yellow-darker text-green-darkest hover:text-white font-bold py-2 px-4 rounded"
+                                    asp-action="ExternalLogin"
+                                    asp-route-provider="@provider.AuthenticationScheme"
+                                    asp-route-returnUrl="@Model.ReturnUrl">
+                                    @provider.DisplayName
+                                </a>
+                            </li>
+                        }
+                    </ul>
+                </p>
+                }
+            </form>
+        </div>
+    </section>
 </div>
 
 @section Scripts {

--- a/src/NZFurs.Auth/Views/Account/LoginWith2fa.cshtml
+++ b/src/NZFurs.Auth/Views/Account/LoginWith2fa.cshtml
@@ -5,18 +5,18 @@
     ViewData["Title"] = @SharedLocalizer.GetLocalizedHtmlString("ACCOUNT_LOGIN_2FA");
 }
 
-<h2>@ViewData["Title"]</h2>
+<h2 class="text-2xl m-6 text-nz-green-light text-center">@ViewData["Title"]</h2>
 <hr />
 <p>@SharedLocalizer.GetLocalizedHtmlString("ACCOUNT_LOGIN_2FA_TEXT")</p>
 <div class="row">
     <div class="col-md-4">
         <form method="post" asp-route-returnUrl="@ViewData["ReturnUrl"]">
             <input asp-for="RememberMe" type="hidden" />
-            <div asp-validation-summary="All" class="text-danger"></div>
+            <div asp-validation-summary="All" class="text-red"></div>
             <div class="form-group">
                 <label asp-for="TwoFactorCode">@SharedLocalizer.GetLocalizedHtmlString("ACCOUNT_LOGIN_AUTHENTICATOR_CODE")</label>
                 <input asp-for="TwoFactorCode" class="form-control" autocomplete="off" />
-                <span asp-validation-for="TwoFactorCode" class="text-danger"></span>
+                <span asp-validation-for="TwoFactorCode" class="text-red"></span>
             </div>
             <div class="form-group">
                 <div class="checkbox">

--- a/src/NZFurs.Auth/Views/Account/LoginWithRecoveryCode.cshtml
+++ b/src/NZFurs.Auth/Views/Account/LoginWithRecoveryCode.cshtml
@@ -5,7 +5,7 @@
     ViewData["Title"] = @SharedLocalizer.GetLocalizedHtmlString("ACCOUNT_RECOVERY_CODE_VERIFICATION");
 }
 
-<h2>@ViewData["Title"]</h2>
+<h2 class="text-2xl m-6 text-nz-green-light text-center">@ViewData["Title"]</h2>
 <hr />
 <p>
     @SharedLocalizer.GetLocalizedHtmlString("ACCOUNT_RECOVERY_CODE_VERIFICATION_TEXT")
@@ -13,11 +13,11 @@
 <div class="row">
     <div class="col-md-4">
         <form method="post">
-            <div asp-validation-summary="All" class="text-danger"></div>
+            <div asp-validation-summary="All" class="text-red"></div>
             <div class="form-group">
                 <label asp-for="RecoveryCode">@SharedLocalizer.GetLocalizedHtmlString("ACCOUNT_RECOVERY_CODE")</label>
                 <input asp-for="RecoveryCode" class="form-control" autocomplete="off" />
-                <span asp-validation-for="RecoveryCode" class="text-danger"></span>
+                <span asp-validation-for="RecoveryCode" class="text-red"></span>
             </div>
             <button type="submit" class="btn btn-primary">@SharedLocalizer.GetLocalizedHtmlString("ACCOUNT_LOGIN")</button>
         </form>

--- a/src/NZFurs.Auth/Views/Account/Logout.cshtml
+++ b/src/NZFurs.Auth/Views/Account/Logout.cshtml
@@ -2,22 +2,18 @@
 @using NZFurs.Auth.Resources
 @model NZFurs.Auth.Models.AccountViewModels.LogoutViewModel
 
-<div class="logout-page">
-    <div class="page-header">
-        <h1>@SharedLocalizer.GetLocalizedHtmlString("LOGOUT")</h1>
-    </div>
+<h2 class="text-2xl m-6 text-nz-green-light text-center">@SharedLocalizer.GetLocalizedHtmlString("LOGOUT")</h1>
 
-    <div class="row">
-        <div class="col-sm-6">
-            <p>@SharedLocalizer.GetLocalizedHtmlString("WOULD_YOU_LIKE_TO_LOGOUT")</p>
-            <form asp-action="Logout">
-                <input type="hidden" name="logoutId" value="@Model.LogoutId" />
-                <fieldset>
-                    <div class="form-group">
-                        <button class="btn btn-primary">@SharedLocalizer.GetLocalizedHtmlString("YES")</button>
-                    </div>
-                </fieldset>
-            </form>
-        </div>
+<div class="container mx-auto h-full flex justify-center items-center">
+    <div class="w-1/3">
+        <h4 class="text-l mt-10 mb-4  text-nz-green-light text-center">@SharedLocalizer.GetLocalizedHtmlString("WOULD_YOU_LIKE_TO_LOGOUT")</h4>
+        <form asp-action="Logout">
+            <input type="hidden" name="logoutId" value="@Model.LogoutId" />
+            <fieldset>
+                <div>
+                    <button class="w-full mt-8 bg-yellow hover:bg-yellow-darker text-green-darkest hover:text-white font-bold py-2 px-4 rounded">@SharedLocalizer.GetLocalizedHtmlString("YES")</button>
+                </div>
+            </fieldset>
+        </form>
     </div>
 </div>

--- a/src/NZFurs.Auth/Views/Account/Register.cshtml
+++ b/src/NZFurs.Auth/Views/Account/Register.cshtml
@@ -5,39 +5,44 @@
     ViewData["Title"] = @SharedLocalizer.GetLocalizedHtmlString("REGISTER");
 }
 
-<h2>@ViewData["Title"].</h2>
+<h2 class="text-2xl m-6 text-nz-green-light text-center">@ViewData["Title"].</h2>
 
-<form asp-controller="Account" asp-action="Register" asp-route-returnurl="@ViewData["ReturnUrl"]" method="post" class="form-horizontal">
-    <h4>@SharedLocalizer.GetLocalizedHtmlString("CREATE_A_NEW_ACCOUNT")</h4>
-    <hr />
-    <div asp-validation-summary="All" class="text-danger"></div>
-    <div class="form-group">
-        <label asp-for="Email" class="col-md-2 control-label">@SharedLocalizer.GetLocalizedHtmlString("EMAIL")</label>
-        <div class="col-md-10">
-            <input asp-for="Email" class="form-control" />
-            <span asp-validation-for="Email" class="text-danger"></span>
+<div class="container mx-auto h-full flex justify-center items-center">
+    <section>
+        <div class="p-8 bg-nz-green-light mb-6 rounded-lg">
+            <form asp-controller="Account" asp-action="Register" asp-route-returnurl="@ViewData["ReturnUrl"]" method="post" class="form-horizontal">
+                <hr />
+                <div asp-validation-summary="All" class="text-red"></div>
+                <div class="mb-4">
+                    <label asp-for="Email" class="font-bold text-green-darkest block mb-2">@SharedLocalizer.GetLocalizedHtmlString("EMAIL")</label>
+                    <div class="col-md-10">
+                        <input asp-for="Email" class="block appearance-none w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" />
+                        <span asp-validation-for="Email" class="text-red"></span>
+                    </div>
+                </div>
+                <div class="mb-4">
+                    <label asp-for="Password" class="font-bold text-green-darkest block mb-2">@SharedLocalizer.GetLocalizedHtmlString("PASSWORD")</label>
+                    <div class="col-md-10">
+                        <input asp-for="Password" class="block appearance-none w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" />
+                        <span asp-validation-for="Password" class="text-red"></span>
+                    </div>
+                </div>
+                <div class="mb-4">
+                    <label asp-for="ConfirmPassword" class="font-bold text-green-darkest block mb-2">@SharedLocalizer.GetLocalizedHtmlString("CONFIRM_PASSWORD")</label>
+                    <div class="col-md-10">
+                        <input asp-for="ConfirmPassword" class="block appearance-none w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" />
+                        <span asp-validation-for="ConfirmPassword" class="text-red"></span>
+                    </div>
+                </div>
+                <div class="mb-4">
+                    <div class="col-md-offset-2 col-md-10">
+                        <button type="submit" class="w-full mt-8 bg-yellow hover:bg-yellow-darker text-green-darkest hover:text-white font-bold py-2 px-4 rounded">@SharedLocalizer.GetLocalizedHtmlString("REGISTER")</button>
+                    </div>
+                </div>
+            </form>
         </div>
-    </div>
-    <div class="form-group">
-        <label asp-for="Password" class="col-md-2 control-label">@SharedLocalizer.GetLocalizedHtmlString("PASSWORD")</label>
-        <div class="col-md-10">
-            <input asp-for="Password" class="form-control" />
-            <span asp-validation-for="Password" class="text-danger"></span>
-        </div>
-    </div>
-    <div class="form-group">
-        <label asp-for="ConfirmPassword" class="col-md-2 control-label">@SharedLocalizer.GetLocalizedHtmlString("CONFIRM_PASSWORD")</label>
-        <div class="col-md-10">
-            <input asp-for="ConfirmPassword" class="form-control" />
-            <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
-        </div>
-    </div>
-    <div class="form-group">
-        <div class="col-md-offset-2 col-md-10">
-            <button type="submit" class="btn btn-primary">@SharedLocalizer.GetLocalizedHtmlString("REGISTER")</button>
-        </div>
-    </div>
-</form>
+    </section>
+</div>
 
 @section Scripts {
     @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }

--- a/src/NZFurs.Auth/Views/Account/ResetPassword.cshtml
+++ b/src/NZFurs.Auth/Views/Account/ResetPassword.cshtml
@@ -4,31 +4,31 @@
 @{
     ViewData["Title"] = @SharedLocalizer.GetLocalizedHtmlString("RESET_PASSWORD");
 }
-<h2>@ViewData["Title"]</h2>
+<h2 class="text-2xl m-6 text-nz-green-light text-center">@ViewData["Title"]</h2>
 <form asp-controller="Account" asp-action="ResetPassword" method="post" class="form-horizontal">
-    <h4>@SharedLocalizer.GetLocalizedHtmlString("RESET_YOUR_PASSWORD")</h4>
+    <h4 class="text-l mt-10 mb-4  text-nz-green-light text-center">@SharedLocalizer.GetLocalizedHtmlString("RESET_YOUR_PASSWORD")</h4>
     <hr />
-    <div asp-validation-summary="All" class="text-danger"></div>
+    <div asp-validation-summary="All" class="text-red"></div>
     <input asp-for="Code" type="hidden" />
     <div class="form-group">
         <label asp-for="Email" class="col-md-2 control-label">@SharedLocalizer.GetLocalizedHtmlString("EMAIL")</label>
         <div class="col-md-10">
             <input asp-for="Email" class="form-control" />
-            <span asp-validation-for="Email" class="text-danger"></span>
+            <span asp-validation-for="Email" class="text-red"></span>
         </div>
     </div>
     <div class="form-group">
         <label asp-for="Password" class="col-md-2 control-label">@SharedLocalizer.GetLocalizedHtmlString("PASSWORD")</label>
         <div class="col-md-10">
             <input asp-for="Password" class="form-control" />
-            <span asp-validation-for="Password" class="text-danger"></span>
+            <span asp-validation-for="Password" class="text-red"></span>
         </div>
     </div>
     <div class="form-group">
         <label asp-for="ConfirmPassword" class="col-md-2 control-label">@SharedLocalizer.GetLocalizedHtmlString("CONFIRM_PASSWORD")</label>
         <div class="col-md-10">
             <input asp-for="ConfirmPassword" class="form-control" />
-            <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
+            <span asp-validation-for="ConfirmPassword" class="text-red"></span>
         </div>
     </div>
     <div class="form-group">

--- a/src/NZFurs.Auth/Views/Account/ResetPasswordConfirmation.cshtml
+++ b/src/NZFurs.Auth/Views/Account/ResetPasswordConfirmation.cshtml
@@ -3,10 +3,15 @@
 @{
     ViewData["Title"] = @SharedLocalizer.GetLocalizedHtmlString("RESET_PASSWORD_CONFIRMATION");
 }
-<h1>@ViewData["Title"].</h1>
-<p>
-    @SharedLocalizer.GetLocalizedHtmlString("RESET_PASSWORD_YOUR_PASSWORD_HAS_BEEN_RESET") <a asp-controller="Account" asp-action="Login">@SharedLocalizer.GetLocalizedHtmlString("RESET_PASSWORD_CLICK_HERE_TO_LOGIN")</a>.
-</p>
-<p>
-    @SharedLocalizer.GetLocalizedHtmlString("RESET_PASSWORD_CONFIRMATION_TEXT1")<a asp-controller="Account" asp-action="Login">@SharedLocalizer.GetLocalizedHtmlString("RESET_PASSWORD_CONFIRMATION_CLICK_HERE")</a>.
-</p>
+<h2 class="text-2xl m-6 text-nz-green-light text-center">@ViewData["Title"].</h2>
+<div class="container mx-auto h-full flex justify-center items-center">
+    <div class="w-1/3">
+        <p>
+            @SharedLocalizer.GetLocalizedHtmlString("RESET_PASSWORD_YOUR_PASSWORD_HAS_BEEN_RESET") <a asp-controller="Account" asp-action="Login">@SharedLocalizer.GetLocalizedHtmlString("RESET_PASSWORD_CLICK_HERE_TO_LOGIN")</a>.
+        </p>
+        <p>
+            @SharedLocalizer.GetLocalizedHtmlString("RESET_PASSWORD_CONFIRMATION_TEXT1")<a asp-controller="Account" asp-action="Login">@SharedLocalizer.GetLocalizedHtmlString("RESET_PASSWORD_CONFIRMATION_CLICK_HERE")</a>.
+        </p>
+    </div>
+</div>
+

--- a/src/NZFurs.Auth/Views/Account/SendCode.cshtml
+++ b/src/NZFurs.Auth/Views/Account/SendCode.cshtml
@@ -5,7 +5,7 @@
     ViewData["Title"] = "Send Verification Code";@SharedLocalizer.GetLocalizedHtmlString("SEND_VERIFICATION_CODE");
 }
 
-<h2>@ViewData["Title"]</h2>
+<h2 class="text-2xl m-6 text-nz-green-light text-center">@ViewData["Title"]</h2>
 
 <form asp-controller="Account" asp-action="SendCode" asp-route-returnurl="@Model.ReturnUrl" method="post" class="form-horizontal">
     <input asp-for="RememberMe" type="hidden" />

--- a/src/NZFurs.Auth/Views/Account/VerifyCode.cshtml
+++ b/src/NZFurs.Auth/Views/Account/VerifyCode.cshtml
@@ -6,20 +6,20 @@
 }
 
 
-<h2>@ViewData["Title"].</h2>
+<h2 class="text-2xl m-6 text-nz-green-light text-center">@ViewData["Title"].</h2>
 
 <form asp-controller="Account" asp-action="VerifyCode" asp-route-returnurl="@ViewData["ReturnUrl"]" method="post" class="form-horizontal">
-    <div asp-validation-summary="All" class="text-danger"></div>
+    <div asp-validation-summary="All" class="text-red"></div>
     <input asp-for="Provider" type="hidden" />
     <input asp-for="RememberMe" type="hidden" />
     <input asp-for="ReturnUrl" type="hidden" />
-    <h4>@ViewData["Status"]</h4>
+    <h4 class="text-l mt-10 mb-4  text-nz-green-light text-center">@ViewData["Status"]</h4>
     <hr />
     <div class="form-group">
         <label asp-for="Code" class="col-md-2 control-label">@SharedLocalizer.GetLocalizedHtmlString("VERIFICATION_CODE")</label>
         <div class="col-md-10">
             <input asp-for="Code" class="form-control" />
-            <span asp-validation-for="Code" class="text-danger"></span>
+            <span asp-validation-for="Code" class="text-red"></span>
         </div>
     </div>
     <div class="form-group">

--- a/src/NZFurs.Auth/Views/Home/Index.cshtml
+++ b/src/NZFurs.Auth/Views/Home/Index.cshtml
@@ -6,7 +6,7 @@
 
 @if (User.Identity.IsAuthenticated)
 {
-    <h1>Hi @User.Identity.Name</h1>
+    <h1 class="text-4xl m-6 text-nz-green-light text-center">Hi @User.Identity.Name</h1>
 }
 else
 {

--- a/src/NZFurs.Auth/Views/Manage/ChangePassword.cshtml
+++ b/src/NZFurs.Auth/Views/Manage/ChangePassword.cshtml
@@ -7,28 +7,28 @@
     ViewData.AddActivePage(ManageNavPages.ChangePassword);
 }
 
-<h4>@ViewData["Title"]</h4>
+<h4 class="text-l mt-10 mb-4  text-nz-green-light text-center">@ViewData["Title"]</h4>
 @await Html.PartialAsync("_StatusMessage", Model.StatusMessage)
-<div class="row">
-    <div class="col-md-6">
+<div class="container mx-auto h-full flex justify-center items-center">
+    <div class="w-1/3">
         <form method="post">
-            <div asp-validation-summary="All" class="text-danger"></div>
-            <div class="form-group">
-                <label asp-for="OldPassword">@SharedLocalizer.GetLocalizedHtmlString("CURRENT_PASSWORD")</label>
-                <input asp-for="OldPassword" class="form-control" />
-                <span asp-validation-for="OldPassword" class="text-danger"></span>
+            <div asp-validation-summary="All" class="text-red"></div>
+            <div class="mb-4">
+                <label class="font-bold text-nz-green-light block mb-2" asp-for="OldPassword">@SharedLocalizer.GetLocalizedHtmlString("CURRENT_PASSWORD")</label>
+                <input asp-for="OldPassword" class="block appearance-none max-w-full w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" />
+                <span asp-validation-for="OldPassword" class="text-red"></span>
             </div>
-            <div class="form-group">
-                <label asp-for="NewPassword">@SharedLocalizer.GetLocalizedHtmlString("NEW_PASSWORD")</label>
-                <input asp-for="NewPassword" class="form-control" />
-                <span asp-validation-for="NewPassword" class="text-danger"></span>
+            <div class="mb-4">
+                <label class="font-bold text-nz-green-light block mb-2" asp-for="NewPassword">@SharedLocalizer.GetLocalizedHtmlString("NEW_PASSWORD")</label>
+                <input asp-for="NewPassword" class="block appearance-none max-w-full w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" />
+                <span asp-validation-for="NewPassword" class="text-red"></span>
             </div>
-            <div class="form-group">
-                <label asp-for="ConfirmPassword">@SharedLocalizer.GetLocalizedHtmlString("CONFIRM_PASSWORD")</label>
-                <input asp-for="ConfirmPassword" class="form-control" />
-                <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
+            <div class="mb-4">
+                <label class="font-bold text-nz-green-light block mb-2" asp-for="ConfirmPassword">@SharedLocalizer.GetLocalizedHtmlString("CONFIRM_PASSWORD")</label>
+                <input asp-for="ConfirmPassword" class="block appearance-none max-w-full w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" />
+                <span asp-validation-for="ConfirmPassword" class="text-red"></span>
             </div>
-            <button type="submit" class="btn btn-primary">@SharedLocalizer.GetLocalizedHtmlString("UPDATE_PASSWORD")</button>
+            <button type="submit" class="w-full mt-8 bg-yellow hover:bg-yellow-darker text-green-darkest hover:text-white font-bold py-2 px-4 rounded">@SharedLocalizer.GetLocalizedHtmlString("UPDATE_PASSWORD")</button>
         </form>
     </div>
 </div>

--- a/src/NZFurs.Auth/Views/Manage/DeletePersonalData.cshtml
+++ b/src/NZFurs.Auth/Views/Manage/DeletePersonalData.cshtml
@@ -7,28 +7,32 @@
     ViewData["ActivePage"] = ManageNavPages.DeletePersonalData;
 }
 
-<h4>@ViewData["Title"]</h4>
+<h4 class="text-l mt-10 mb-4  text-nz-green-light text-center">@ViewData["Title"]</h4>
 
-<div class="alert alert-warning" role="alert">
-    <p>
-        <span class="fas fa-exclamation-triangle"></span>
-        <strong>@SharedLocalizer.GetLocalizedHtmlString("DELETE_PERSONAL_DATA_TEXT")</strong>
-    </p>
-</div>
+<div class="container mx-auto h-full flex justify-center items-center">
+    <div class="w-1/3">
+        <div class="text-red" role="alert">
+            <p>
+                <span class="fas fa-exclamation-triangle"></span>
+                <strong>@SharedLocalizer.GetLocalizedHtmlString("DELETE_PERSONAL_DATA_TEXT")</strong>
+            </p>
+        </div>
 
-<div>
-    <form id="delete-user" method="post" class="form-group">
-        <div asp-validation-summary="All" class="text-danger"></div>
-        @if (Model.RequirePassword)
-        {
-            <div class="form-group">
-                <label asp-for="Password">@SharedLocalizer.GetLocalizedHtmlString("PASSWORD")</label>
-                <input asp-for="Password" class="form-control" />
-                <span asp-validation-for="Password" class="text-danger"></span>
-            </div>
-        }
-        <button class="btn btn-danger" type="submit">@SharedLocalizer.GetLocalizedHtmlString("DELETE_PERSONAL_DATA_AND_CLOSE")</button>
-    </form>
+        <div>
+            <form id="delete-user" method="post" class="form-group">
+                <div asp-validation-summary="All" class="text-red"></div>
+                @if (Model.RequirePassword)
+                {
+                    <div class="form-group">
+                        <label asp-for="Password" class="mt-4 font-bold text-nz-green-light block mb-2">@SharedLocalizer.GetLocalizedHtmlString("PASSWORD")</label>
+                        <input asp-for="Password" class="max-w-full w-full block appearance-none w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" />
+                        <span asp-validation-for="Password" class="text-red"></span>
+                    </div>
+                }
+                <button class="w-full mt-8 mb-8 bg-red hover:bg-red-darker text-white font-bold py-2 px-4 rounded" type="submit">@SharedLocalizer.GetLocalizedHtmlString("DELETE_PERSONAL_DATA_AND_CLOSE")</button>
+            </form>
+        </div>
+    </div>
 </div>
 
 @section Scripts {

--- a/src/NZFurs.Auth/Views/Manage/Disable2fa.cshtml
+++ b/src/NZFurs.Auth/Views/Manage/Disable2fa.cshtml
@@ -6,21 +6,25 @@
     ViewData.AddActivePage(ManageNavPages.TwoFactorAuthentication);
 }
 
-<h2>@ViewData["Title"]</h2>
+<h2 class="text-2xl m-6 text-nz-green-light text-center">@ViewData["Title"]</h2>
 
-<div class="alert alert-warning" role="alert">
-    <p>
-        <span class="fas fa-exclamation-triangle"></span>
-        <strong>@SharedLocalizer.GetLocalizedHtmlString("DISABLE_2FA_TEXT_HEADER")</strong>
-    </p>
-    <p>
-        @SharedLocalizer.GetLocalizedHtmlString("DISABLE_2FA_TEXT_DETAILS")
-        <a asp-action="ResetAuthenticatorWarning">@SharedLocalizer.GetLocalizedHtmlString("DISABLE_2FA_TEXT_DETAILS_LINK")</a>
-    </p>
-</div>
+<div class="container mx-auto h-full flex justify-center items-center">
+    <div class="w-1/3">
+        <div class="text-red mb-4" role="alert">
+            <p>
+                <span class="fas fa-exclamation-triangle"></span>
+                <strong>@SharedLocalizer.GetLocalizedHtmlString("DISABLE_2FA_TEXT_HEADER")</strong>
+            </p>
+        </div>
+        <p>
+            @SharedLocalizer.GetLocalizedHtmlString("DISABLE_2FA_TEXT_DETAILS")
+            <a asp-action="ResetAuthenticatorWarning">@SharedLocalizer.GetLocalizedHtmlString("DISABLE_2FA_TEXT_DETAILS_LINK")</a>
+        </p>
 
-<div>
-    <form asp-action="Disable2fa" method="post" class="form-group">
-        <button class="btn btn-danger" type="submit">@SharedLocalizer.GetLocalizedHtmlString("DISABLE_2FA_BUTTON")</button>
-    </form>
+        <div>
+            <form asp-action="Disable2fa" method="post" class="form-group">
+                <button class="w-full mt-8 mb-8 bg-red hover:bg-red-darker text-white font-bold py-2 px-4 rounded" type="submit">@SharedLocalizer.GetLocalizedHtmlString("DISABLE_2FA_BUTTON")</button>
+            </form>
+        </div>
+    </div>
 </div>

--- a/src/NZFurs.Auth/Views/Manage/DownloadPersonalData.cshtml
+++ b/src/NZFurs.Auth/Views/Manage/DownloadPersonalData.cshtml
@@ -6,7 +6,7 @@
     ViewData["ActivePage"] = ManageNavPages.DownloadPersonalData;
 }
 
-<h4>@ViewData["Title"]</h4>
+<h4 class="text-l mt-10 mb-4  text-nz-green-light text-center">@ViewData["Title"]</h4>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/src/NZFurs.Auth/Views/Manage/EnableAuthenticator.cshtml
+++ b/src/NZFurs.Auth/Views/Manage/EnableAuthenticator.cshtml
@@ -7,7 +7,7 @@
     ViewData.AddActivePage(ManageNavPages.TwoFactorAuthentication);
 }
 
-<h4>@ViewData["Title"]</h4>
+<h4 class="text-l mt-10 mb-4  text-nz-green-light text-center">@ViewData["Title"]</h4>
 <div>
     <p>@SharedLocalizer.GetLocalizedHtmlString("CONFIGURE_AUTHENTICATOR_APP_STEPS")</p>
     <ol class="list">
@@ -32,16 +32,16 @@
             <p>
                 @SharedLocalizer.GetLocalizedHtmlString("CONFIGURE_AUTHENTICATOR_APP_SCAN_ALERT_DETAILS")
             </p>
-            <div class="row">
-                <div class="col-md-6">
+            <div class="container mx-auto h-full flex justify-center items-center">
+                <div class="w-1/3">
                     <form method="post">
-                        <div class="form-group">
-                            <label asp-for="Code" class="control-label">@SharedLocalizer.GetLocalizedHtmlString("VERIFICATION_CODE")</label>
-                            <input asp-for="Code" class="form-control" autocomplete="off" />
-                            <span asp-validation-for="Code" class="text-danger"></span>
+                        <div class="mb-4">
+                            <label asp-for="Code" class="font-bold text-nz-green-light block mb-2">@SharedLocalizer.GetLocalizedHtmlString("VERIFICATION_CODE")</label>
+                            <input asp-for="Code" class="block appearance-none max-w-full w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" autocomplete="off" />
+                            <span asp-validation-for="Code" class="text-red"></span>
                         </div>
-                        <button type="submit" class="btn btn-primary">@SharedLocalizer.GetLocalizedHtmlString("VERIFY")</button>
-                        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                        <button type="submit" class="w-full mt-8 bg-yellow hover:bg-yellow-darker text-green-darkest hover:text-white font-bold py-2 px-4 rounded">@SharedLocalizer.GetLocalizedHtmlString("VERIFY")</button>
+                        <div asp-validation-summary="ModelOnly" class="text-red"></div>
                     </form>
                 </div>
             </div>

--- a/src/NZFurs.Auth/Views/Manage/ExternalLogins.cshtml
+++ b/src/NZFurs.Auth/Views/Manage/ExternalLogins.cshtml
@@ -7,49 +7,53 @@
     ViewData.AddActivePage(ManageNavPages.ExternalLogins);
 }
 
-@await Html.PartialAsync("_StatusMessage", Model.StatusMessage)
-@if (Model.CurrentLogins?.Count > 0)
-{
-    <h4>@SharedLocalizer.GetLocalizedHtmlString("EXTERNAL_LOGINS_REGISTERED_LOGIN")</h4>
-    <table class="table">
-        <tbody>
-            @foreach (var login in Model.CurrentLogins)
-            {
-                <tr>
-                    <td>@login.LoginProvider</td>
-                    <td>
-                        @if (Model.ShowRemoveButton)
+<div class="container mx-auto h-full flex justify-center items-center">
+    <div class="w-1/3">
+        @await Html.PartialAsync("_StatusMessage", Model.StatusMessage)
+        @if (Model.CurrentLogins?.Count > 0)
+        {
+            <h4 class="text-l mt-10 mb-4  text-nz-green-light text-center">@SharedLocalizer.GetLocalizedHtmlString("EXTERNAL_LOGINS_REGISTERED_LOGIN")</h4>
+            <table class="table">
+                <tbody>
+                    @foreach (var login in Model.CurrentLogins)
+                    {
+                        <tr>
+                            <td>@login.LoginProvider</td>
+                            <td>
+                                @if (Model.ShowRemoveButton)
+                                {
+                                    <form asp-action="RemoveLogin" method="post">
+                                        <div>
+                                            <input asp-for="@login.LoginProvider" name="LoginProvider" type="hidden" />
+                                            <input asp-for="@login.ProviderKey" name="ProviderKey" type="hidden" />
+                                            <button type="submit" class="w-full mb-4 bg-yellow hover:bg-yellow-darker text-green-darkest hover:text-white font-bold py-2 px-4 rounded" title="Remove this @login.LoginProvider login from your account">@SharedLocalizer.GetLocalizedHtmlString("REMOVE")</button>
+                                        </div>
+                                    </form>
+                                }
+                                else
+                                {
+                                    @: &nbsp;
+                                }
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        }
+        @if (Model.OtherLogins?.Count > 0)
+        {
+            <h4 class="text-l mt-10 mb-4  text-nz-green-light text-center">@SharedLocalizer.GetLocalizedHtmlString("EXTERNAL_LOGINS_ADD_ANOTHER_SERVICE_TO_LOGIN")</h4>
+            <hr />
+            <form asp-action="LinkLogin" method="post" class="form-horizontal">
+                <div id="socialLoginList">
+                    <p>
+                        @foreach (var provider in Model.OtherLogins)
                         {
-                            <form asp-action="RemoveLogin" method="post">
-                                <div>
-                                    <input asp-for="@login.LoginProvider" name="LoginProvider" type="hidden" />
-                                    <input asp-for="@login.ProviderKey" name="ProviderKey" type="hidden" />
-                                    <button type="submit" class="btn btn-primary" title="Remove this @login.LoginProvider login from your account">@SharedLocalizer.GetLocalizedHtmlString("REMOVE")</button>
-                                </div>
-                            </form>
+                            <button type="submit" class="w-full mb-4 bg-yellow hover:bg-yellow-darker text-green-darkest hover:text-white font-bold py-2 px-4 rounded" name="provider" value="@provider.Name" title="Log in using your @provider.DisplayName account">@provider.DisplayName</button>
                         }
-                        else
-                        {
-                            @: &nbsp;
-                        }
-                    </td>
-                </tr>
-            }
-        </tbody>
-    </table>
-}
-@if (Model.OtherLogins?.Count > 0)
-{
-    <h4>@SharedLocalizer.GetLocalizedHtmlString("EXTERNAL_LOGINS_ADD_ANOTHER_SERVICE_TO_LOGIN")</h4>
-    <hr />
-    <form asp-action="LinkLogin" method="post" class="form-horizontal">
-        <div id="socialLoginList">
-            <p>
-                @foreach (var provider in Model.OtherLogins)
-                {
-                    <button type="submit" class="btn btn-primary" name="provider" value="@provider.Name" title="Log in using your @provider.DisplayName account">@provider.DisplayName</button>
-                }
-            </p>
-        </div>
-    </form>
-}
+                    </p>
+                </div>
+            </form>
+        }
+    </div>
+</div>

--- a/src/NZFurs.Auth/Views/Manage/GenerateRecoveryCodes.cshtml
+++ b/src/NZFurs.Auth/Views/Manage/GenerateRecoveryCodes.cshtml
@@ -6,24 +6,30 @@
     ViewData.AddActivePage(ManageNavPages.TwoFactorAuthentication);
 }
 
-<h2>@ViewData["Title"]</h2>
+<h2 class="text-2xl m-6 text-nz-green-light text-center">@ViewData["Title"]</h2>
 
-<div class="alert alert-warning" role="alert">
-    <p>
-        <span class="fas fa-exclamation-triangle"></span>
-        <strong>@SharedLocalizer.GetLocalizedHtmlString("GENERATE_2FA_RECOVERY_CODES_SAFE_PLACE")</strong>
-    </p>
-    <p>
-        @SharedLocalizer.GetLocalizedHtmlString("GENERATE_2FA_RECOVERY_CODES_INFO_LOSE")
-    </p>
-    <p>
-        @SharedLocalizer.GetLocalizedHtmlString("GENERATE_2FA_RECOVERY_CODES_TEXT")
-        <a asp-action="ResetAuthenticatorWarning">@SharedLocalizer.GetLocalizedHtmlString("GENERATE_2FA_RECOVERY_CODES_TEXT_LINK")</a>
-    </p>
-</div>
+<div class="container mx-auto h-full flex justify-center items-center">
+    <div class="w-1/3">
+        <div class="text-red mb-4" role="alert">
+            <p>
+                <span class="fas fa-exclamation-triangle"></span>
+                <strong>@SharedLocalizer.GetLocalizedHtmlString("GENERATE_2FA_RECOVERY_CODES_SAFE_PLACE")</strong>
+            </p>
+        </div>
+        <div class="text-white">
+            <p>
+                @SharedLocalizer.GetLocalizedHtmlString("GENERATE_2FA_RECOVERY_CODES_INFO_LOSE")
+            </p>
+            <p>
+                @SharedLocalizer.GetLocalizedHtmlString("GENERATE_2FA_RECOVERY_CODES_TEXT")
+                <a asp-action="ResetAuthenticatorWarning">@SharedLocalizer.GetLocalizedHtmlString("GENERATE_2FA_RECOVERY_CODES_TEXT_LINK")</a>
+            </p>
+        </div>
 
-<div>
-    <form asp-action="GenerateRecoveryCodes" method="post" class="form-group">
-        <button class="btn btn-danger" type="submit">@SharedLocalizer.GetLocalizedHtmlString("GENERATE_RECOVERY_CODES")</button>
-    </form>
+        <div>
+            <form asp-action="GenerateRecoveryCodes" method="post" class="form-group">
+                <button class="w-full mt-8 mb-8 bg-red hover:bg-red-darker text-white font-bold py-2 px-4 rounded" type="submit">@SharedLocalizer.GetLocalizedHtmlString("GENERATE_RECOVERY_CODES")</button>
+            </form>
+        </div>
+    </div>
 </div>

--- a/src/NZFurs.Auth/Views/Manage/Index.cshtml
+++ b/src/NZFurs.Auth/Views/Manage/Index.cshtml
@@ -7,38 +7,38 @@
     ViewData.AddActivePage(ManageNavPages.Index);
 }
 
-<h4>@ViewData["Title"]</h4>
+<h4 class="text-l mt-10 mb-4  text-nz-green-light text-center">@ViewData["Title"]</h4>
 @await Html.PartialAsync("_StatusMessage", Model.StatusMessage)
-<div class="row">
-    <div class="col-md-6">
+<div class="container mx-auto h-full flex justify-center items-center">
+    <div class="w-1/3">
         <form method="post">
-            <div asp-validation-summary="All" class="text-danger"></div>
-            <div class="form-group">
-                <label asp-for="Username">@SharedLocalizer.GetLocalizedHtmlString("USERNAME")</label>
-                <input asp-for="Username" class="form-control" disabled />
+            <div asp-validation-summary="All" class="text-red"></div>
+            <div class="mb-4">
+                <label class="font-bold text-nz-green-light block mb-2" asp-for="Username">@SharedLocalizer.GetLocalizedHtmlString("USERNAME")</label>
+                <input asp-for="Username" class="block appearance-none max-w-full w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" disabled />
             </div>
-            <div class="form-group">
-                <label asp-for="Email">@SharedLocalizer.GetLocalizedHtmlString("EMAIL")</label>
+            <div class="mb-4">
+                <label class="font-bold text-nz-green-light block mb-2" asp-for="Email">@SharedLocalizer.GetLocalizedHtmlString("EMAIL")</label>
                 @if (Model.IsEmailConfirmed)
                 {
                     <div class="input-group">
-                        <input asp-for="Email" class="form-control" />
+                        <input asp-for="Email" class="mb-2 block appearance-none max-w-full w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" />
                         <span class="input-group-addon" aria-hidden="true"><span class="fas fa-check-circle text-success"></span></span>
                     </div>
                 }
                 else
                 {
-                    <input asp-for="Email" class="form-control" />
-                    <button asp-action="SendVerificationEmail" class="btn btn-link">@SharedLocalizer.GetLocalizedHtmlString("SEND_VERIFICATION_EMAIL")</button>
+                    <input asp-for="Email" class="mb-2 block appearance-none max-w-full w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" />
+                    <button asp-action="SendVerificationEmail" class="w-full bg-nz-green-light text-green-darkest font-bold py-2 px-4 rounded">@SharedLocalizer.GetLocalizedHtmlString("SEND_VERIFICATION_EMAIL")</button>
                 }
-                <span asp-validation-for="Email" class="text-danger"></span>
+                <span asp-validation-for="Email" class="text-red"></span>
             </div>
-            <div class="form-group">
-                <label asp-for="PhoneNumber">@SharedLocalizer.GetLocalizedHtmlString("PHONE_NUMBER")</label>
-                <input asp-for="PhoneNumber" class="form-control" />
-                <span asp-validation-for="PhoneNumber" class="text-danger"></span>
+            <div class="mb-4">
+                <label class="font-bold text-nz-green-light block mb-2" asp-for="PhoneNumber">@SharedLocalizer.GetLocalizedHtmlString("PHONE_NUMBER")</label>
+                <input asp-for="PhoneNumber" class="block max-w-full w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" />
+                <span asp-validation-for="PhoneNumber" class="text-red"></span>
             </div>
-            <button type="submit" class="btn btn-primary">@SharedLocalizer.GetLocalizedHtmlString("SAVE")</button>
+            <button type="submit" class="w-full mt-8 bg-yellow hover:bg-yellow-darker text-green-darkest hover:text-white font-bold py-2 px-4 rounded">@SharedLocalizer.GetLocalizedHtmlString("SAVE")</button>
         </form>
     </div>
 </div>

--- a/src/NZFurs.Auth/Views/Manage/PersonalData.cshtml
+++ b/src/NZFurs.Auth/Views/Manage/PersonalData.cshtml
@@ -6,19 +6,19 @@
     ViewData["ActivePage"] = ManageNavPages.PersonalData;
 }
 
-<h4>@ViewData["Title"]</h4>
+<h4 class="text-l mt-10 mb-4  text-nz-green-light text-center">@ViewData["Title"]</h4>
 
-<div class="row">
-    <div class="col-md-6">
-        <p>@SharedLocalizer.GetLocalizedHtmlString("PERSONAL_DATA_INFO")</p>
-        <p>
+<div class="container mx-auto h-full flex justify-center items-center">
+    <div class="w-1/3">
+        <p class="mb-4">@SharedLocalizer.GetLocalizedHtmlString("PERSONAL_DATA_INFO")</p>
+        <p class="text-red">
             <strong>@SharedLocalizer.GetLocalizedHtmlString("PERSONAL_DATA_DELETEINFO")</strong>
         </p>
         <form asp-action="DownloadPersonalData" method="post" class="form-group">
-            <button class="btn btn-primary" type="submit">@SharedLocalizer.GetLocalizedHtmlString("DOWNLOAD")</button>
+            <button class="w-full mt-8 mb-8 bg-yellow hover:bg-yellow-darker text-green-darkest hover:text-white font-bold py-2 px-4 rounded" type="submit">@SharedLocalizer.GetLocalizedHtmlString("DOWNLOAD")</button>
         </form>
-        <p>
-            <a asp-action="DeletePersonalData" class="btn btn-primary">@SharedLocalizer.GetLocalizedHtmlString("DELETE")</a>
+        <p class="text-center">
+            <a asp-action="DeletePersonalData" class="no-underline center bg-red hover:bg-red-darker text-white font-bold py-2 px-4 rounded">@SharedLocalizer.GetLocalizedHtmlString("DELETE")</a>
         </p>
     </div>
 </div>

--- a/src/NZFurs.Auth/Views/Manage/ResetAuthenticator.cshtml
+++ b/src/NZFurs.Auth/Views/Manage/ResetAuthenticator.cshtml
@@ -6,18 +6,25 @@
     ViewData.AddActivePage(ManageNavPages.TwoFactorAuthentication);
 }
 
-<h4>@ViewData["Title"]</h4>
-<div class="alert alert-warning" role="alert">
-    <p>
-        <span class="fas fa-exclamation-triangle"></span>
-        <strong>@SharedLocalizer.GetLocalizedHtmlString("RESET_AUTHENTICATOR_INFO")</strong>
-    </p>
-    <p>
-        @SharedLocalizer.GetLocalizedHtmlString("RESET_AUTHENTICATOR_TEXT")
-    </p>
-</div>
-<div>
-    <form asp-action="ResetAuthenticator" method="post" class="form-group">
-        <button class="btn btn-danger" type="submit">@SharedLocalizer.GetLocalizedHtmlString("RESET_AUTHENTICATOR_KEY")</button>
-    </form>
+<h4 class="text-l mt-10 mb-4 text-nz-green-light text-center">@ViewData["Title"]</h4>
+
+<div class="container mx-auto h-full flex justify-center items-center">
+    <div class="w-1/3">
+        <div class="text-red mb-4" role="alert">
+            <p>
+                <span class="fas fa-exclamation-triangle"></span>
+                <strong>@SharedLocalizer.GetLocalizedHtmlString("RESET_AUTHENTICATOR_INFO")</strong>
+            </p>
+        </div>
+        <div class="text-white">
+            <p>
+                @SharedLocalizer.GetLocalizedHtmlString("RESET_AUTHENTICATOR_TEXT")
+            </p>
+        </div>
+        <div>
+            <form asp-action="ResetAuthenticator" method="post" class="form-group">
+                <button class="w-full mt-8 bg-yellow hover:bg-yellow-darker text-green-darkest hover:text-white font-bold py-2 px-4 rounded" type="submit">@SharedLocalizer.GetLocalizedHtmlString("RESET_AUTHENTICATOR_KEY")</button>
+            </form>
+        </div>
+    </div>
 </div>

--- a/src/NZFurs.Auth/Views/Manage/SetPassword.cshtml
+++ b/src/NZFurs.Auth/Views/Manage/SetPassword.cshtml
@@ -7,26 +7,26 @@
     ViewData.AddActivePage(ManageNavPages.ChangePassword);
 }
 
-<h4>@SharedLocalizer.GetLocalizedHtmlString("SET_YOUR_PASSWORD")</h4>
+<h4 class="text-l mt-10 mb-4  text-nz-green-light text-center">@SharedLocalizer.GetLocalizedHtmlString("SET_YOUR_PASSWORD")</h4>
 @await Html.PartialAsync("_StatusMessage", Model.StatusMessage)
 <p class="text-info">
     @SharedLocalizer.GetLocalizedHtmlString("SET_PASSWORD_TEXT")
 </p>
-<div class="row">
-    <div class="col-md-6">
+<div class="container mx-auto h-full flex justify-center items-center">
+    <div class="w-1/3">
         <form method="post">
-            <div asp-validation-summary="All" class="text-danger"></div>
+            <div asp-validation-summary="All" class="text-red"></div>
             <div class="form-group">
-                <label asp-for="NewPassword">@SharedLocalizer.GetLocalizedHtmlString("PASSWORD")</label>
-                <input asp-for="NewPassword" class="form-control" />
-                <span asp-validation-for="NewPassword" class="text-danger"></span>
+                <label class="font-bold text-nz-green-light block mb-2" asp-for="NewPassword">@SharedLocalizer.GetLocalizedHtmlString("PASSWORD")</label>
+                <input asp-for="NewPassword" class="block appearance-none max-w-full w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" />
+                <span asp-validation-for="NewPassword" class="text-red"></span>
             </div>
             <div class="form-group">
-                <label asp-for="ConfirmPassword">@SharedLocalizer.GetLocalizedHtmlString("CONFIRM_PASSWORD")</label>
-                <input asp-for="ConfirmPassword" class="form-control" />
-                <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
+                <label class="font-bold text-nz-green-light block mb-2" asp-for="ConfirmPassword">@SharedLocalizer.GetLocalizedHtmlString("CONFIRM_PASSWORD")</label>
+                <input asp-for="ConfirmPassword" class="block appearance-none max-w-full w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" />
+                <span asp-validation-for="ConfirmPassword" class="text-red"></span>
             </div>
-            <button type="submit" class="btn btn-primary">@SharedLocalizer.GetLocalizedHtmlString("SET_PASSWORD")</button>
+            <button type="submit" class="w-full mt-8 bg-yellow hover:bg-yellow-darker text-green-darkest hover:text-white font-bold py-2 px-4 rounded">@SharedLocalizer.GetLocalizedHtmlString("SET_PASSWORD")</button>
         </form>
     </div>
 </div>

--- a/src/NZFurs.Auth/Views/Manage/ShowRecoveryCodes.cshtml
+++ b/src/NZFurs.Auth/Views/Manage/ShowRecoveryCodes.cshtml
@@ -7,9 +7,9 @@
     ViewData.AddActivePage(ManageNavPages.TwoFactorAuthentication);
 }
 
-<h4>@ViewData["Title"]</h4>
-<div class="alert alert-warning" role="alert">
-    <p>
+<h4 class="text-l mt-10 mb-4  text-nz-green-light text-center">@ViewData["Title"]</h4>
+<div class="text-red" role="alert">
+    <p class="mb-4">
         <span class="fas fa-exclamation-triangle"></span>
         <strong>@SharedLocalizer.GetLocalizedHtmlString("Put these codes in a safe place.")</strong>
     </p>
@@ -17,8 +17,8 @@
         @SharedLocalizer.GetLocalizedHtmlString("If you lose your device and don't have the recovery codes you will lose access to your account.")
     </p>
 </div>
-<div class="row">
-    <div class="col-md-12">
+<div class="container mx-auto h-full flex justify-center items-center">
+    <div class="w-1/3">
         @for (var row = 0; row < Model.RecoveryCodes.Length; row += 2)
         {
             <code>@Model.RecoveryCodes[row]</code><text>&nbsp;</text><code>@Model.RecoveryCodes[row + 1]</code><br />

--- a/src/NZFurs.Auth/Views/Manage/TwoFactorAuthentication.cshtml
+++ b/src/NZFurs.Auth/Views/Manage/TwoFactorAuthentication.cshtml
@@ -7,45 +7,49 @@
     ViewData.AddActivePage(ManageNavPages.TwoFactorAuthentication);
 }
 
-<h4>@ViewData["Title"]</h4>
-@if (Model.Is2faEnabled)
-{
-    if (Model.RecoveryCodesLeft == 0)
-    {
-        <div class="alert alert-danger">
-            <strong>@SharedLocalizer.GetLocalizedHtmlString("2FA_NO_CODES_LEFT")</strong>
-            <p>@SharedLocalizer.GetLocalizedHtmlString("2FA_NO_CODES_LEFT_TEXT") <a asp-action="GenerateRecoveryCodes">@SharedLocalizer.GetLocalizedHtmlString("GENERATE")</a></p>
-        </div>
-    }
-    else if (Model.RecoveryCodesLeft == 1)
-    {
-        <div class="alert alert-danger">
-            <strong>@SharedLocalizer.GetLocalizedHtmlString("2FA_ONE_CODES_LEFT")</strong>
-            <p>@SharedLocalizer.GetLocalizedHtmlString("2FA_ONE_CODES_LEFT_TEXT")  You can generate a new set of recovery codes. <a asp-action="GenerateRecoveryCodes">@SharedLocalizer.GetLocalizedHtmlString("GENERATE")</a></p>
-        </div>
-    }
-    else if (Model.RecoveryCodesLeft <= 3)
-    {
-        <div class="alert alert-warning">
-            <strong>@SharedLocalizer.GetLocalizedHtmlString("2FA_N_CODES_LEFT", @Model.RecoveryCodesLeft.ToString())</strong>
-            <p>@SharedLocalizer.GetLocalizedHtmlString("2FA_N_CODES_LEFT_TEXT") <a asp-action="GenerateRecoveryCodes">@SharedLocalizer.GetLocalizedHtmlString("GENERATE")</a></p>
-        </div>
-    }
+<h4 class="text-l mt-10 mb-4  text-nz-green-light text-center">@ViewData["Title"]</h4>
 
-    <a asp-action="Disable2faWarning" class="btn btn-primary">@SharedLocalizer.GetLocalizedHtmlString("DISABLE_2FA_BUTTON")</a>
-    <a asp-action="GenerateRecoveryCodesWarning" class="btn btn-primary">@SharedLocalizer.GetLocalizedHtmlString("RESET_RECOVERY_CODES")</a>
-}
+<div class="container mx-auto h-full flex justify-center items-center">
+    <div class="w-1/3">
+        @if (Model.Is2faEnabled)
+        {
+            if (Model.RecoveryCodesLeft == 0)
+            {
+                <div class="alert alert-danger">
+                    <strong>@SharedLocalizer.GetLocalizedHtmlString("2FA_NO_CODES_LEFT")</strong>
+                    <p>@SharedLocalizer.GetLocalizedHtmlString("2FA_NO_CODES_LEFT_TEXT") <a asp-action="GenerateRecoveryCodes">@SharedLocalizer.GetLocalizedHtmlString("GENERATE")</a></p>
+                </div>
+            }
+            else if (Model.RecoveryCodesLeft == 1)
+            {
+                <div class="alert alert-danger">
+                    <strong>@SharedLocalizer.GetLocalizedHtmlString("2FA_ONE_CODES_LEFT")</strong>
+                    <p>@SharedLocalizer.GetLocalizedHtmlString("2FA_ONE_CODES_LEFT_TEXT")  You can generate a new set of recovery codes. <a asp-action="GenerateRecoveryCodes">@SharedLocalizer.GetLocalizedHtmlString("GENERATE")</a></p>
+                </div>
+            }
+            else if (Model.RecoveryCodesLeft <= 3)
+            {
+                <div class="alert alert-warning">
+                    <strong>@SharedLocalizer.GetLocalizedHtmlString("2FA_N_CODES_LEFT", @Model.RecoveryCodesLeft.ToString())</strong>
+                    <p>@SharedLocalizer.GetLocalizedHtmlString("2FA_N_CODES_LEFT_TEXT") <a asp-action="GenerateRecoveryCodes">@SharedLocalizer.GetLocalizedHtmlString("GENERATE")</a></p>
+                </div>
+            }
 
-<h5>@SharedLocalizer.GetLocalizedHtmlString("AUTHENTICATOR_APP")</h5>
-@if (!Model.HasAuthenticator)
-{
-    <a id="enable-authenticator"  asp-action="EnableAuthenticator" class="btn btn-primary">@SharedLocalizer.GetLocalizedHtmlString("2FA_AUTHENTICATION_ADD_AUTHENTICATOR_APP")</a>
-}
-else
-{
-    <a id="enable-authenticator" asp-action="EnableAuthenticator" class="btn btn-primary">@SharedLocalizer.GetLocalizedHtmlString("2FA_AUTHENTICATION_ADD_SETUP_APP")</a>
-    <a id="reset-authenticator" asp-action="ResetAuthenticatorWarning" class="btn btn-primary">@SharedLocalizer.GetLocalizedHtmlString("2FA_AUTHENTICATION_ADD_RESET_APP")</a>
-}
+            <a asp-action="Disable2faWarning" class="w-full mt-8 bg-yellow hover:bg-yellow-darker text-green-darkest hover:text-white font-bold py-2 px-4 rounded">@SharedLocalizer.GetLocalizedHtmlString("DISABLE_2FA_BUTTON")</a>
+            <a asp-action="GenerateRecoveryCodesWarning" class="w-full mt-8 bg-yellow hover:bg-yellow-darker text-green-darkest hover:text-white font-bold py-2 px-4 rounded">@SharedLocalizer.GetLocalizedHtmlString("RESET_RECOVERY_CODES")</a>
+        }
+
+        @if (!Model.HasAuthenticator)
+        {
+            <a id="enable-authenticator"  asp-action="EnableAuthenticator" class="no-underline text-yellow hover:text-white font-bold">@SharedLocalizer.GetLocalizedHtmlString("2FA_AUTHENTICATION_ADD_AUTHENTICATOR_APP")</a>
+        }
+        else
+        {
+            <a id="enable-authenticator" asp-action="EnableAuthenticator" class="mr-4 no-underline text-yellow hover:text-white font-bold">@SharedLocalizer.GetLocalizedHtmlString("2FA_AUTHENTICATION_ADD_SETUP_APP")</a>
+            <a id="reset-authenticator" asp-action="ResetAuthenticatorWarning" class="no-underline text-yellow hover:text-white font-bold">@SharedLocalizer.GetLocalizedHtmlString("2FA_AUTHENTICATION_ADD_RESET_APP")</a>
+        }
+    </div>
+</div>
 
 @section Scripts {
     @await Html.PartialAsync("_ValidationScriptsPartial")

--- a/src/NZFurs.Auth/Views/Manage/_Layout.cshtml
+++ b/src/NZFurs.Auth/Views/Manage/_Layout.cshtml
@@ -4,19 +4,11 @@
     Layout = "/Views/Shared/_Layout.cshtml";
 }
 
-<h2>@SharedLocalizer.GetLocalizedHtmlString("MANAGE_YOUR_ACCOUNT")</h2>
+<h2 class="text-2xl m-6 text-nz-green-light text-center">@SharedLocalizer.GetLocalizedHtmlString("MANAGE_YOUR_ACCOUNT")</h2>
 
 <div>
-    <h4>@SharedLocalizer.GetLocalizedHtmlString("MANAGE_CHANGE_ACCOUNT_SETTINGS")</h4>
-    <hr />
-    <div class="row">
-        <div class="col-md-3">
-            @await Html.PartialAsync("_ManageNav")
-        </div>
-        <div class="col-md-9">
-            @RenderBody()
-        </div>
-    </div>
+    @await Html.PartialAsync("_ManageNav")
+    @RenderBody()
 </div>
 
 @section Scripts {

--- a/src/NZFurs.Auth/Views/Manage/_ManageNav.cshtml
+++ b/src/NZFurs.Auth/Views/Manage/_ManageNav.cshtml
@@ -7,15 +7,15 @@
     var hasExternalLogins = (await SignInManager.GetExternalAuthenticationSchemesAsync()).Any();
 }
 
-<nav class="navbar navbar-light">
-    <ul class="mr-auto navbar-nav">
-        <li class="nav-item @ManageNavPages.IndexNavClass(ViewContext)"><a class="nav-link" asp-action="Index">@SharedLocalizer.GetLocalizedHtmlString("PROFILE")</a></li>
-        <li class="nav-item @ManageNavPages.ChangePasswordNavClass(ViewContext)"><a class="nav-link" id="change-password" asp-action="ChangePassword">@SharedLocalizer.GetLocalizedHtmlString("PASSWORD")</a></li>
+<nav class="container mx-auto h-full flex justify-center items-center">
+    <ul class="flex list-reset">
+        <li class="mr-3 ml-3 @ManageNavPages.IndexNavClass(ViewContext)"><a class="no-underline text-yellow hover:text-white font-bold" asp-action="Index">@SharedLocalizer.GetLocalizedHtmlString("PROFILE")</a></li>
+        <li class="mr-3 ml-3 @ManageNavPages.ChangePasswordNavClass(ViewContext)"><a class="no-underline text-yellow hover:text-white font-bold" id="change-password" asp-action="ChangePassword">@SharedLocalizer.GetLocalizedHtmlString("PASSWORD")</a></li>
         @if (hasExternalLogins)
         {
-            <li class="nav-item @ManageNavPages.ExternalLoginsNavClass(ViewContext)"><a class="nav-link" id="external-login" asp-action="ExternalLogins">@SharedLocalizer.GetLocalizedHtmlString("EXTERNAL_LOGINS")</a></li>
+            <li class="mr-3 ml-3 @ManageNavPages.ExternalLoginsNavClass(ViewContext)"><a class="no-underline text-yellow hover:text-white font-bold" id="external-login" asp-action="ExternalLogins">@SharedLocalizer.GetLocalizedHtmlString("EXTERNAL_LOGINS")</a></li>
         }
-        <li class="nav-item @ManageNavPages.TwoFactorAuthenticationNavClass(ViewContext)"><a class="nav-link" asp-action="TwoFactorAuthentication">@SharedLocalizer.GetLocalizedHtmlString("2FA")</a></li>
-        <li class="nav-item @ManageNavPages.PersonalDataNavClass(ViewContext)"><a class="nav-link" asp-action="PersonalData">@SharedLocalizer.GetLocalizedHtmlString("PERSONAL_DATA")</a></li>
+        <li class="mr-3 ml-3 @ManageNavPages.TwoFactorAuthenticationNavClass(ViewContext)"><a class="no-underline text-yellow hover:text-white font-bold" asp-action="TwoFactorAuthentication">@SharedLocalizer.GetLocalizedHtmlString("2FA")</a></li>
+        <li class="mr-3 ml-3 @ManageNavPages.PersonalDataNavClass(ViewContext)"><a class="no-underline text-yellow hover:text-white font-bold" asp-action="PersonalData">@SharedLocalizer.GetLocalizedHtmlString("PERSONAL_DATA")</a></li>
     </ul>
 </nav>

--- a/src/NZFurs.Auth/Views/Manage/_StatusMessage.cshtml
+++ b/src/NZFurs.Auth/Views/Manage/_StatusMessage.cshtml
@@ -3,7 +3,7 @@
 @if (!String.IsNullOrEmpty(Model))
 {
     var statusMessageClass = Model.StartsWith("Error") ? "danger" : "success";
-    <div class="alert alert-@statusMessageClass alert-dismissible" role="alert">
+    <div class="text-red alert-@statusMessageClass alert-dismissible" role="alert">
         <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
         @Model
     </div>

--- a/src/NZFurs.Auth/Views/Shared/_Layout.cshtml
+++ b/src/NZFurs.Auth/Views/Shared/_Layout.cshtml
@@ -17,7 +17,7 @@
             <div class="flex items-center flex-no-shrink text-green-darkest hover:text-nz-green-light mr-6">
                 <svg class="fill-current h-8 w-8 mr-2" width="54" height="54" viewBox="0 0 54 54" xmlns="http://www.w3.org/2000/svg"><path d="M13.5 22.1c1.8-7.2 6.3-10.8 13.5-10.8 10.8 0 12.15 8.1 17.55 9.45 3.6.9 6.75-.45 9.45-4.05-1.8 7.2-6.3 10.8-13.5 10.8-10.8 0-12.15-8.1-17.55-9.45-3.6-.9-6.75.45-9.45 4.05zM0 38.3c1.8-7.2 6.3-10.8 13.5-10.8 10.8 0 12.15 8.1 17.55 9.45 3.6.9 6.75-.45 9.45-4.05-1.8 7.2-6.3 10.8-13.5 10.8-10.8 0-12.15-8.1-17.55-9.45-3.6-.9-6.75.45-9.45 4.05z"/></svg>
                 <a asp-controller="Home" asp-action="Index" class="no-underline block mt-4 lg:inline-block lg:mt-0 text-xl text-green-darkest hover:text-green-darkest mr-4">
-                    <em>login.furry.nz</em>
+                    <em>NZFurs</em>
                 </a>
             </div>
             <div class="w-full block flex-grow lg:flex lg:items-center lg:w-auto">
@@ -30,18 +30,12 @@
 
     </div>
 
-    <div >
+    <div class="text-white">
         @RenderBody()
-       
     </div>
 
     <footer>
-        <hr />
-        <nav class="flex items-center justify-between flex-wrap bg-white p-6">
-            <p>&copy; 2018 - login.furry.nz</p>
-
-            @await Html.PartialAsync("_SelectLanguagePartial")
-        </nav>
+    
     </footer>
 
     <script src="~/js/vendor.min.js" asp-append-version="true"></script>


### PR DESCRIPTION
This extends Tailwind CSS into other Views on the site. I've added an example of the updates as screenshots and a summary of typical patterns used, such as classes for text inputs, buttons, etc.

<img width="836" alt="Screen Shot 2019-10-12 at 7 12 42 PM" src="https://user-images.githubusercontent.com/42904161/66696183-3da0cf80-ed26-11e9-96de-ff3f0aa92f3c.png">
<img width="838" alt="Screen Shot 2019-10-12 at 7 15 48 PM" src="https://user-images.githubusercontent.com/42904161/66696186-40032980-ed26-11e9-80c8-70bcb71a9a49.png">
<img width="838" alt="Screen Shot 2019-10-12 at 7 16 16 PM" src="https://user-images.githubusercontent.com/42904161/66696187-41cced00-ed26-11e9-9ed1-92ae152a0eab.png">
<img width="838" alt="Screen Shot 2019-10-12 at 7 16 33 PM" src="https://user-images.githubusercontent.com/42904161/66696190-4396b080-ed26-11e9-9174-0baa8c71ef9d.png">


# Common Patterns
- Home/Index Heading: `<h1 class="text-4xl m-6 text-nz-green-light text-center">`
- Subpage Heading: `<h2 class="text-2xl m-6 text-nz-green-light text-center">`
- Subheading/Section Heading: `<h4 class="text-l m-6 text-nz-green-light text-center">`
- Center content:
```
<div class="container mx-auto h-full flex justify-center items-center">
    <div class="w-1/3">
        ...
    </div>
</div>
```
- Form:
```
    ...
        <form>
            <div class="mb-4">
                <label ...>
            </div>
            <div class="mb-4">
                <label ...>
                ...
```
- Labels: `<label class="font-bold text-nz-green-light block mb-2"></label/`
- Inputs (full width): `<input class="block appearance-none max-w-full w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded"/>`
- Secondary Button (Green, Full Width): `<button type="submit" class="w-full bg-nz-green-light text-green-darkest font-bold py-2 px-4 rounded">`
- Confirmation Button (Yellow, full width): `<button type="submit" class="w-full mt-8 bg-yellow hover:bg-yellow-darker text-green-darkest hover:text-white font-bold py-2 px-4 rounded">`
- Danger Confirmation Button (Red): `<button class="w-full mt-8 mb-8 bg-red hover:bg-red-darker text-white font-bold py-2 px-4 rounded" type="submit">`
