### PR TITLE
Login modal changes, mainly css and layout for responsiveness

### DIFF
--- a/src/NZFurs.Auth/Views/Account/Login.cshtml
+++ b/src/NZFurs.Auth/Views/Account/Login.cshtml
@@ -9,7 +9,7 @@
 
 <h2 class="text-2xl m-6 text-nz-green-light text-center">@ViewData["Title"]</h2>
 <div class="container mx-auto h-full flex justify-center items-center">
-    <div class="w-1/3">
+    <div class="w-4/5 sm:w-4/5 md:w-1/2">
         <section>
             <div class="p-8 bg-nz-green-light mb-6 rounded-lg">
                 <form asp-controller="Account" asp-action="Login" asp-route-returnurl="@Model.ReturnUrl" method="post"  >
@@ -17,28 +17,30 @@
                     <div class="mb-4">
                         <label class="font-bold text-green-darkest block mb-2" >@SharedLocalizer.GetLocalizedHtmlString("EMAIL")</label>
                         <div  >
-                            <input asp-for="Email" class="block appearance-none w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" />
-                            <span asp-validation-for="Email" class="text-red" ></span>
+                            <input asp-for="Email" class="text-center block appearance-none w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" />
+                            <span asp-validation-for="Email" class="inline-block mt-3 text-red" ></span>
                         </div>
                     </div>
                     <div class="mb-4">
                         <label class="font-bold text-green-darkest block mb-2" >@SharedLocalizer.GetLocalizedHtmlString("PASSWORD")</label>
                         <div  >
-                            <input asp-for="Password" class="block appearance-none w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" />
-                            <span asp-validation-for="Password" class="text-red" ></span>
+                            <input type="password" asp-for="Password" class="text-center block appearance-none w-full bg-white border border-grey-light hover:border-grey px-2 py-2 rounded" />
+                            <span asp-validation-for="Password" class="inline-block mt-3 text-red" ></span>
                         </div>
                     </div>
                     <div class="mb-4 text-green-darkest">
-                        <label  >@SharedLocalizer.GetLocalizedHtmlString("REMEMBER_ME")</label>
+                        <label  >@SharedLocalizer.GetLocalizedHtmlString("REMEMBER_ME")&nbsp;</label>
                         <input asp-for="RememberLogin"  />
                     </div>
                     <div class="mb-4">
                         <div class="flex items-center justify-between">
-                            <button type="submit" class="bg-yellow hover:bg-yellow-darker text-green-darkest hover:text-white font-bold py-2 px-4 rounded" >@SharedLocalizer.GetLocalizedHtmlString("ACCOUNT_LOGIN")</button>
+                            <button type="submit" class="w-full bg-yellow hover:bg-yellow-darker text-green-darkest hover:text-white font-bold py-2 px-4 rounded" >@SharedLocalizer.GetLocalizedHtmlString("ACCOUNT_LOGIN")</button>
                         </div>
                     </div>
-                    <p class="mt-3 mb-10">
-                        <a class="mb-4 text-green-darkest hover:text-yellow-darker no-underline" asp-action="ForgotPassword">@SharedLocalizer.GetLocalizedHtmlString("FORGOT_YOUR_PASSWORD")</a>
+                    <p class="mt-3">
+                        <a class="mb-4 text-green-darkest hover:text-yellow-darker no-underline" asp-action="ForgotPassword">
+                            <button class="w-full bg-yellow hover:bg-yellow-darker text-green-darkest hover:text-white font-bold py-2 px-4 rounded" >@SharedLocalizer.GetLocalizedHtmlString("FORGOT_YOUR_PASSWORD")</button>
+                        </a>
                     </p>
                     @if (Model.ExternalProviders.Any())
                     {

--- a/src/NZFurs.Auth/wwwroot/css/site.css
+++ b/src/NZFurs.Auth/wwwroot/css/site.css
@@ -11,7 +11,7 @@
 }
 
 /* Set widths on the form inputs since otherwise they're 100% wide */
-input,
+/* I've removed "input" from this as it's constrained by the parent div in most cases and looks weird on mobile --skooch */
 select,
 textarea {
     max-width: 280px;


### PR DESCRIPTION
This commit pertains to the Login modal that is displayed.
Changes include:

 - Fix responsiveness, previously on small screens the layout
   would look awful.

 - Make the buttons and inputs 100% width of parents as the modal
   parent object is constrained and responsive already. This
   makes things easier to click

 - Fixes validation errors not having proper margins by adding
   them and setting the spans to inline-block

 - Center the text within the input